### PR TITLE
Small fix when calling `response.throttled`

### DIFF
--- a/src/middleware/response/throttling.js
+++ b/src/middleware/response/throttling.js
@@ -9,8 +9,10 @@ module.exports = function(client, request, response, next){
     var retryAfter = parseInt(response.headers['retry'] || response.headers['retry-after'], 10) * 1000 || 1000;
     setTimeout(function(){
       client._execute(request, function(error, response){
-        response.throttled = true;
-        response.retries = ++request.retries;
+        if(response){
+          response.throttled = true;
+          response.retries = ++request.retries;
+        }
         setTimeout(function(){
           request.callback(error, response);
         });


### PR DESCRIPTION
Hey @misbach! Here's a fix for a small thing I saw in production. While throttling, if no response is given, the call to `response.throttled` can result in "Cannot set properties of undefined (setting 'throttled')". 